### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-msoffice",
   "version": "2.0.1-rc0",
   "author": "puppet",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "Module for managing Microsoft Office",
   "source": "https://github.com/voxpupuli/puppet-msoffice",
   "project_page": "https://github.com/voxpupuli/puppet-msoffice",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time