### PR TITLE
Address the local Administrators group by its well-known SID rather than by name

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,4 @@ fixtures:
     stdlib:  https://github.com/puppetlabs/puppetlabs-stdlib.git
     powershell:  https://github.com/puppetlabs/puppetlabs-powershell.git
     win_facts:  https://github.com/liamjbennett/puppet-win_facts.git
+    windows_account_names:  https://github.com/natemccurdy/windows_account_names.git

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -98,7 +98,7 @@ define msoffice::package(
           content => template('msoffice/setup.ini.erb'),
           mode    => '0755',
           owner   => 'Administrator',
-          group   => 'Administrators',
+          group   => 'S-1-5-32-544',
         }
 
         exec { 'install-office':
@@ -115,7 +115,7 @@ define msoffice::package(
           content => template('msoffice/config.erb'),
           mode    => '0755',
           owner   => 'Administrator',
-          group   => 'Administrators',
+          group   => 'S-1-5-32-544',
         }
 
         exec { 'install-office':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -97,7 +97,7 @@ define msoffice::package(
         file { "${msoffice::params::temp_dir}\\office_config.ini":
           content => template('msoffice/setup.ini.erb'),
           mode    => '0755',
-          owner   => 'Administrator',
+          owner   => $facts['windows_accounts']['Administrator'],
           group   => 'S-1-5-32-544',
         }
 
@@ -114,7 +114,7 @@ define msoffice::package(
         file { "${msoffice::params::temp_dir}\\office_config.xml":
           content => template('msoffice/config.erb'),
           mode    => '0755',
-          owner   => 'Administrator',
+          owner   => $facts['windows_accounts']['Administrator'],
           group   => 'S-1-5-32-544',
         }
 

--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,10 @@
     {
       "name": "liamjbennett/win_facts",
       "version_requirement": ">= 0.0.2 < 2.0.0"
+    },
+    {
+      "name": "nate/windows_account_names",
+      "version_requirement": ">= 2.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Names of security objects built into Windows depend on the installation-time language. For example on a German system the "local administrators" group is called Administratoren rather than Administrators, causing puppet-msoffice to fail because being unable to set the correct owner group on office_config.xml. To make things worse, once set those names cannot be modified even when the default OS language is changed - if you want to rename Administratoren to Administrators you have to reinstall Windows.

Luckily, Puppet now understands Windows security identifiers and there is a well-known SID corresponding to Administrators regardless of the language used. Change _group => 'Administrators'_ to _group => 'S-1-5-32-544'_ and it will work regardless of whether your copy of Windows has been installed in English, German, Swahili, or Klingon.

Nb. Ideally the name of the built-in administrator user should be replaced by a SID too, especially given that in addition to language dependency that name can be changed by a certain Group Policy setting. Unfortunately that one is more tricky because its well-known SID is not fully static and I don't know if Puppet can be told to match user as  _S-1-5-<something>-500_. On the other hand, I have yet to see this particular bit of puppet-msoffice fail even though the built-in administrator account isn't called Administrator on **any** of the machines I work with - so maybe Puppet handles this one internally.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
