### PR TITLE
Installer fails due to incorrect servicepack id Office 2013

### DIFF
--- a/manifests/servicepack.pp
+++ b/manifests/servicepack.pp
@@ -41,7 +41,7 @@ define msoffice::servicepack(
 
   validate_re($version,'^(2003|2007|2010|2013|2016)$', 'The version argument specified does not match a valid version of office')
   validate_re($arch,'^(x86|x64)$', 'The arch argument specified does not match x86 or x64')
-  validate_re($sp,'^([1-3])$','The service pack specified does not match 1-3')
+  validate_re($sp,'^([0-3])$','The service pack specified does not match 1-3')
 
 
   $office_build = $msoffice::params::office_versions[$version]['service_packs'][$sp]['build']

--- a/manifests/servicepack.pp
+++ b/manifests/servicepack.pp
@@ -41,7 +41,7 @@ define msoffice::servicepack(
 
   validate_re($version,'^(2003|2007|2010|2013|2016)$', 'The version argument specified does not match a valid version of office')
   validate_re($arch,'^(x86|x64)$', 'The arch argument specified does not match x86 or x64')
-  validate_re($sp,'^([0-3])$','The service pack specified does not match 1-3')
+  validate_re($sp,'^([0-3])$','The service pack specified does not match 0-3')
 
 
   $office_build = $msoffice::params::office_versions[$version]['service_packs'][$sp]['build']


### PR DESCRIPTION
Office 2013 parameter defines a servicepack with id 0. However due to the validator this is "incorrect".