### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -132,7 +132,7 @@ class msoffice::params {
         },
         'Standard' => {
           'products' => ['Word','Excel','Powerpoint','OneNote','Outlook','Publisher'],
-          'office_product' => 'Standardr',
+          'office_product' => 'Standard',
         },
         'Professional' => {
           'products' => ['Word','Excel','Powerpoint','OneNote','Outlook','Access'],


### PR DESCRIPTION
Fixes following errors when installing Office 2010

change from 'notrun' to ['0'] failed: '"\\foo\bar\OFFICE14\Standard\x86\setup.exe" /modify Standardr /config "C:\Windows\Temp\office_config.xml"' returned 30066 instead of one of [0]

Failed to call refresh: '"\\foo\bar\OFFICE14\Standard\x86\setup.exe" /modify Standardr /config "C:\Windows\Temp\office_config.xml"' returned 30066 instead of one of [0]

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Fixes following errors when installing Office 2010

change from 'notrun' to ['0'] failed: '"\\foo\bar\OFFICE14\Standard\x86\setup.exe" /modify Standardr /config "C:\Windows\Temp\office_config.xml"' returned 30066 instead of one of [0]

Failed to call refresh: '"\\foo\bar\OFFICE14\Standard\x86\setup.exe" /modify Standardr /config "C:\Windows\Temp\office_config.xml"' returned 30066 instead of one of [0]
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
